### PR TITLE
Clarify role of Fleet Enrollment token

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ You can review compatibility guidelines [here][1].
 
 The installation process requires:
 - an Elastic Stack deployment (either on prem or on [Elastic Cloud](https://www.elastic.co/cloud/));
-- a running Fleet server;
+- a [running Fleet server](https://www.elastic.co/guide/en/fleet/current/fleet-server.html);
 - a running GCP GKE cluster.
 
 ## Preparing Elastic for Kubernetes monitoring

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,20 @@ We maintain `7.17.x` and `8.x` stack versions.
 Elastic recommends installing the latest version of the Elastic Agent that’s compatible with the version of your Elasticsearch deployment.
 You can review compatibility guidelines [here][1].
 
-By clicking "Configure" a guided process starts to collect some deployment details.
+The installation process requires:
+- an Elastic Stack deployment (either on prem or on [Elastic Cloud](https://www.elastic.co/cloud/));
+- a running Fleet server;
+- a running GCP GKE cluster.
+
+## Preparing Elastic for Kubernetes monitoring
+
+Before installing the application we need to create a Fleet enrollment token, required in the installations step.
+
+To create a Fleet enrollment token you need to have an Agent policy. Then [follow the documentation][4].
+
+## Installing the application from GCP marketplace
+
+By clicking "Configure" (_link to listing TBD_) a guided process starts to collect some deployment details.
 
 You will need to choose:
 - the GKE cluster where to deploy the application: you can select an existing cluster or create a new one;
@@ -16,6 +29,7 @@ You will need to choose:
 - the Service Account of the application; use `default`, **do not change this field**; a dedicated Service Account with required permissions will be created; this field is included because mandatory part of the schema (see [docs][3]);
 - Fleet Server URL to connect to; if left empty Kibana Host, Kibana Fleet Username and Kibana Fleet Password are needed;
 - Fleet enrollment token; is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html. If left empty Kibana Host, Kibana Fleet Username and Kibana Fleet Password are needed;
+**Note** that a Fleet enrollment token is linked to an Agent Policy, and due to this the Agent will be enrolled in Fleet with that policy assigned;
 - Kibana Username; user name to connect to Kibana; this user needs the privileges required to publish events to Elasticsearch;
 - Kibana Fleet Password; password to connect to Kibana;
 - Kibana Host; URL to connect to Kibana; if you're using Elastic Cloud Kibana URL can be found in the console on the deployment details page;
@@ -35,7 +49,7 @@ Here are the steps to verify the installation worked as expected:
 2. verify the Elastic Agent DaemonSet status, by clicking on it under Application Details; check Logs to ensure there are no errors;
 3. verify the Elastic Agent correctly enrolled with your Fleet instance; go to the Agents tab in Fleet and ensure the Agent is present and healthy.
 
-**NOTE** that unless you already configured a policy the Agent will not be collecting data.
+**NOTE** that unless the policy linked to the Fleet enrollment token has some integration configure, the the Agent will not be collecting data yet.
 
 ## Debugging
 
@@ -51,3 +65,4 @@ If you need specific assistance you can:
 [1]: https://www.elastic.co/support/matrix#matrix_compatibility
 [2]: https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements
 [3]: https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/schema.md?rgh-link-date=2022-08-23T11%3A04%3A33Z#type-service_account
+[4]: https://www.elastic.co/guide/en/fleet/master/fleet-enrollment-tokens.html#create-fleet-enrollment-tokens

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -2,9 +2,9 @@
 
 If you successfully installed the application by following the steps [here](./installation.md), great job! Now you're ready to collect some data!
 
-By default the Elastic Agent does not have any policy assigned so will not collect any data.
+By default the Elastic Agent will be assigned the Fleet Integration Policy linked to the Fleet enrollment token you used when installing the application. If that policy has some Integrations configured, the Agent should already be collecting data.
 
-Here is a list of common use cases and how to setup Elastic Agent policies to collect related data.
+If there is no Integration configured, here is a list of common use cases and how to setup Elastic Agent policies to collect related data.
 
 ## Kubernetes Observability
 


### PR DESCRIPTION
The installation docs was not entirely correct: the enrollment automatically enrolls the Agent in Fleet with a specific Agent policy. Depending on the policy configuration, the Agent may be collecting data after enrolling or not.

This PR also clarifies this aspect in the next step section.
