### PR TITLE
Remove standalone mode vars

### DIFF
--- a/8.4.1/deployer/schema.yaml
+++ b/8.4.1/deployer/schema.yaml
@@ -143,23 +143,11 @@ properties:
   FLEET_URL:
     type: string
     title: Fleet server URL
-    description: "Fleet server URL, can be found in Kibana->Management->Fleet->Settings. If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed"
+    description: "Fleet server URL, can be found in Kibana->Management->Fleet->Settings."
   FLEET_ENROLLMENT_TOKEN:
     type: string
     title: Fleet enrollment token
-    description: "A Fleet enrollment token is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html. If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed"
-  KIBANA_FLEET_USERNAME:
-    type: string
-    title: Kibana User Name
-    description: User name to connect to Kibana. Fill it only if FLEET_URL has been left empty.
-  KIBANA_FLEET_PASSWORD:
-    type: string
-    title: Kibana User Password
-    description: Kibana user password to log into the elastic cluster. Fill it only if FLEET_URL has been left empty.
-  KIBANA_HOST:
-    type: string
-    title: Kibana URL
-    description: Kibana Host URL. Fill it only if FLEET_URL has been left empty.
+    description: "A Fleet enrollment token is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html."
   cpuResurceRequest:
     type: string
     title: Container Resource Request - CPU

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,11 +14,8 @@ You will need to choose:
 - the namespace within the GKE cluster to deploy the Application; selecting `default` will deploy the Application to the `default` namespace and the Elastic Agent in the `kube-system` namespace;
 - the application instance name (this is the name of the deployed application in your GKE cluster);
 - the Service Account of the application; use `default`, **do not change this field**; a dedicated Service Account with required permissions will be created; this field is included because mandatory part of the schema (see [docs][3]);
-- Fleet Server URL to connect to; if left empty Kibana Host, Kibana Fleet Username and Kibana Fleet Password are needed;
-- Fleet enrollment token; is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html. If left empty Kibana Host, Kibana Fleet Username and Kibana Fleet Password are needed;
-- Kibana Username; user name to connect to Kibana; this user needs the privileges required to publish events to Elasticsearch;
-- Kibana Fleet Password; password to connect to Kibana;
-- Kibana Host; URL to connect to Kibana; if you're using Elastic Cloud Kibana URL can be found in the console on the deployment details page;
+- Fleet Server URL to connect to;
+- Fleet enrollment token; is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html;
 - Container resource request - CPU; the requested container CPU, depends on use case; more information are available in our [Elastic Agent installation - minimum requirements documentation][2];
 - Container Resource Request - Memory; the requested container memory, depends on use case; more information are available in our [Elastic Agent installation - minimum requirements documentation][2].
 


### PR DESCRIPTION
As per https://github.com/elastic/elastic-agent-gcp-kubernetes-app/issues/4 we are not focusing on Elastic Agent standalone mode support. To prevent confusion from what is available and due to the lack of testing, this PR removes references to vars used for standalone mode from the docs and `8.4.1`.

They are not removed from the template as if empty they are not going to be used anyway and this helps reducing the differences with the original template in the Elastic Agent repository.
