### PR TITLE
Add label annotation for Elastic Agent and update to the latest version 8.17.0

### DIFF
--- a/8.17.0/Dockerfile
+++ b/8.17.0/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/beats/elastic-agent:8.17.0
+
+LABEL com.googleapis.cloudmarketplace.product.service.name="elastic-agent.endpoints.prod-elastic-cloud-billing.cloud.goog"

--- a/8.17.0/deployer/Dockerfile
+++ b/8.17.0/deployer/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst/onbuild
+ENV WAIT_FOR_READY_TIMEOUT 1800
+ENV TESTER_TIMEOUT 1800

--- a/8.17.0/deployer/LICENSE
+++ b/8.17.0/deployer/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/8.17.0/deployer/manifest/application.yaml.template
+++ b/8.17.0/deployer/manifest/application.yaml.template
@@ -1,0 +1,31 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "$name"
+  namespace: "$namespace"
+  annotations:
+    marketplace.cloud.google.com/deploy-info: '{"partner_id": "elastic-saas", "product_id": "elastic-agent", "partner_name": "Elastic"}'
+    com.googleapis.cloudmarketplace.product.service.name: 'elastic-agent.endpoints.prod-elastic-cloud-billing.cloud.goog'
+  labels:
+    app.kubernetes.io/name: "$name"
+spec:
+  descriptor:
+    type: ElasticAgent
+    version: $imageTag
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "$name"
+  componentKinds:
+  # The group is determined from the apiVersion: $GROUP_NAME/$VERSION
+  - group: apps/v1
+    kind: DaemonSet
+  - group: ''
+    kind: ClusterRoleBinding
+  - group: ''
+    kind: RoleBinding
+  - group: ''
+    kind: ClusterRole
+  - group: ''
+    kind: Role
+  - group: ''
+    kind: ServiceAccount

--- a/8.17.0/deployer/manifest/manifests.yaml.template
+++ b/8.17.0/deployer/manifest/manifests.yaml.template
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "$name"
+  namespace: "$namespace"
+  labels:
+    app: "$name"
+spec:
+  selector:
+    matchLabels:
+      app: "$name"
+  template:
+    metadata:
+      labels:
+        app: "$name"
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      automountServiceAccountToken: true
+      serviceAccountName: $agentServiceAccount
+      hostNetwork: true
+      # Sharing the host process ID namespace gives visibility of all processes running on the same host.
+      # This enables the Elastic Security integration to observe all process exec events on the host.
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: elastic-agent
+          image: $image
+          env:
+            - name: FLEET_ENROLL
+              value: "1"
+            # The ip:port pair of fleet server
+            - name: FLEET_URL
+              value: "$FLEET_URL"
+            # If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
+            - name: FLEET_ENROLLMENT_TOKEN
+              value: "$FLEET_ENROLLMENT_TOKEN"
+            - name: KIBANA_HOST
+              value: "$KIBANA_HOST"
+            - name: KIBANA_FLEET_USERNAME
+              value: "$KIBANA_FLEET_USERNAME"
+            - name: KIBANA_FLEET_PASSWORD
+              value: "$KIBANA_FLEET_PASSWORD"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: $cpuResurceRequest
+              memory: $memoryResurceRequest
+          volumeMounts:
+            - name: proc
+              mountPath: /hostfs/proc
+              readOnly: true
+            - name: cgroup
+              mountPath: /hostfs/sys/fs/cgroup
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /hostfs/etc/kubernetes
+              readOnly: true
+            - name: var-lib
+              mountPath: /hostfs/var/lib
+              readOnly: true
+            - name: passwd
+              mountPath: /hostfs/etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /hostfs/etc/group
+              readOnly: true
+            - name: etcsysmd
+              mountPath: /hostfs/etc/systemd
+              readOnly: true
+            - name: etc-mid
+              mountPath: /etc/machine-id
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        - name: var-lib
+          hostPath:
+            path: /var/lib
+        - name: passwd
+          hostPath:
+            path: /etc/passwd
+        - name: group
+          hostPath:
+            path: /etc/group
+        - name: etcsysmd
+          hostPath:
+            path: /etc/systemd
+        - name: etc-mid
+          hostPath:
+            path: /etc/machine-id
+            type: File

--- a/8.17.0/deployer/schema.yaml
+++ b/8.17.0/deployer/schema.yaml
@@ -1,0 +1,165 @@
+x-google-marketplace:
+  schemaVersion: v2
+
+  applicationApiVersion: v1beta1
+
+  publishedVersion: '8.17.0'
+  publishedVersionMetadata:
+    releaseNote: >-
+      See Elastic Agent Release notes at https://www.elastic.co/guide/en/fleet/current/release-notes-8.17.0.html
+    releaseTypes:
+      - Feature
+    recommended: true
+
+  images:
+    '':
+      properties:
+        image:
+          type: FULL
+        imageTag:
+          type: TAG
+
+  # Need for cluster-scoped permissions for the deployer. 
+  # See https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/schema.md#deployerserviceaccount
+  deployerServiceAccount:
+    description: >
+      List clusterrolebindings, clusterroles ...
+    roles:
+    - type: ClusterRole
+      rulesType: CUSTOM
+      rules:
+      - apiGroups: ['rbac.authorization.k8s.io']
+        resources: ['clusterrolebindings', 'clusterroles']
+        verbs: ['get', 'list']
+        
+properties:
+  # All service accounts need to be defined as parameters in schema.yaml
+  # See https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/schema.md#type-service_account
+  agentServiceAccount:
+    type: string
+    title: Agent Service Account
+    description: "Service Account used by the Elastic Agent. Do not change from 'default'."
+    default: elastic-agent
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        description: >
+          Agent Service Account: elastic-agent
+        roles:
+        # https://github.com/elastic/elastic-agent/blob/f26b0eb53fa5b08c23a3145156cd4a245ad04f32/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-role.yaml#L1
+        - type: ClusterRole
+          rulesType: CUSTOM
+          rules:
+          - apiGroups: [""]
+            resources:
+              - nodes
+              - namespaces
+              - events
+              - pods
+              - services
+              - configmaps
+              - serviceaccounts
+              - persistentvolumes
+              - persistentvolumeclaims
+            verbs: ["get", "list", "watch"]
+          # Enable this rule only if planing to use kubernetes_secrets provider
+          #- apiGroups: [""]
+          #  resources:
+          #  - secrets
+          #  verbs: ["get"]
+          - apiGroups: ["extensions"]
+            resources:
+              - replicasets
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["apps"]
+            resources:
+              - statefulsets
+              - deployments
+              - replicasets
+              - daemonsets
+            verbs: ["get", "list", "watch"]
+          - apiGroups:
+              - ""
+            resources:
+              - nodes/stats
+            verbs:
+              - get
+          - apiGroups: [ "batch" ]
+            resources:
+              - jobs
+              - cronjobs
+            verbs: [ "get", "list", "watch" ]
+          # required for apiserver
+          # nonResourceURLs is not supported by this schema: https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/b309eb922897ec4b11356dd975941e20b51ae16c/marketplace/deployer_util/config_helper.py#L981
+          # - nonResourceURLs:
+          #     - "/metrics"
+          #   verbs:
+          #     - get
+          # - apiGroups: ["rbac.authorization.k8s.io"]
+          #   resources:
+          #     - clusterrolebindings
+          #     - clusterroles
+          #     - rolebindings
+          #     - roles
+          #   verbs: ["get", "list", "watch"]
+          - apiGroups: ["policy"]
+            resources:
+              - podsecuritypolicies
+            verbs: ["get", "list", "watch"]
+        # https://github.com/elastic/elastic-agent/blob/f26b0eb53fa5b08c23a3145156cd4a245ad04f32/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-role.yaml#L64
+        - type: Role
+          rulesType: CUSTOM
+          rules:
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs: ["get", "create", "update"]
+        # https://github.com/elastic/elastic-agent/blob/f26b0eb53fa5b08c23a3145156cd4a245ad04f32/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-role.yaml#L79
+        - type: Role
+          rulesType: CUSTOM
+          rules:
+            - apiGroups: [""]
+              resources:
+                - configmaps
+              resourceNames:
+                - kubeadm-config
+              verbs: ["get"]
+
+  name:
+    type: string
+    title: Agent Instance Name
+    description: Agent Instance Name
+    default: elastic-agent
+    x-google-marketplace:
+      type: NAME
+  namespace:
+    type: string
+    title: Agent Namespace
+    description: "Namespace the agent will be deployed to. Do not change from 'default'."
+    default: kube-system
+    x-google-marketplace:
+      type: NAMESPACE
+  FLEET_URL:
+    type: string
+    title: Fleet server URL
+    description: "Fleet server URL, can be found in Kibana->Management->Fleet->Settings."
+  FLEET_ENROLLMENT_TOKEN:
+    type: string
+    title: Fleet enrollment token
+    description: "A Fleet enrollment token is an Elasticsearch API key to enroll one or more Elastic Agents in Fleet. See: https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html."
+  cpuResurceRequest:
+    type: string
+    title: Container Resource Request - CPU
+    description: Container Resource Request - CPU. Ex. 100m. See https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements
+    default: 100m
+  memoryResurceRequest:
+    type: string
+    title: Container Resource Request - Memory
+    description: Container Resource Request - Memory. Ex. 200Mi. See https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements
+    default: 200Mi
+
+required:
+- name
+- namespace
+- agentServiceAccount

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Is possible to install this application in [non-GKE clusters too][2].
 
 Each Elastic Agent version requires some configuration to be made available as a GCP Kubernetes App. The current available versions are:
 
-|Release track|Version|Recommended
-|---|---|---|
-|`7.17`|`7.17.5`||
-|`8.3`|`8.3.3`||
-|`8.4`|`8.4.1`||
-|`8.5`|`8.5.0`|✔|
+| Release track | Version  |Recommended
+|---------------|----------|--|
+| `7.17`        | `7.17.5` ||
+| `8.3`         | `8.3.3`  ||
+| `8.4`         | `8.4.1`  ||
+| `8.5`         | `8.5.0`  ||
+| `8.17`        | `8.17.0` |✔|
 
 ## Documentation
 


### PR DESCRIPTION
This PR updates the Elastic Agent deployment configuration to comply with Google Cloud Marketplace requirements and points to the latest version (8.17.0). The key changes include:

1.	Image Manifest Annotation: Added the mandatory label annotation com.googleapis.cloudmarketplace.product.service.name with the value elastic-agent.endpoints.prod-elastic-cloud-billing.cloud.goog to the Dockerfile for Elastic Agent 8.17.0. This ensures compliance with Google Cloud Marketplace’s annotation requirements effective January 20, 2025.
2.	Version Update: Updated all configuration files to point to Elastic Agent version 8.17.0 as the latest supported version.
3.	No Functional Changes: All files have been borrowed as-is from previous releases, with minimal modifications to include the required annotation and update the version.

These changes ensure compliance with the new Google Cloud Marketplace standards while maintaining functionality consistent with prior versions.